### PR TITLE
[275] Solution

### DIFF
--- a/275.md
+++ b/275.md
@@ -57,3 +57,27 @@ static_assert(not std::is_same_v<decltype("Bar"_cs), to_string_t<"Foo">>);
 > https://godbolt.org/z/adT4rfEbh
 
 </p></details><details><summary>Solutions</summary><p>
+
+```cpp
+template <std::size_t N>
+struct fixed_string final {
+    constexpr explicit(false) fixed_string(const char (&str)[N + 1]) {
+        std::copy_n(str, N + 1, std::data(data));
+    }
+
+    [[nodiscard]] constexpr auto
+    operator<=>(const fixed_string &) const = default;
+
+    std::array<char, N + 1> data{};
+};
+
+template <std::size_t N>
+fixed_string(const char (&str)[N]) -> fixed_string<N - 1>;
+
+template <fixed_string Str>
+using to_string_t = decltype([]<std::size_t... Is>(std::index_sequence<Is...>) {
+    return string<Str.data[Is]...>{};
+}(std::make_index_sequence<Str.data.size() - 1>()))
+```
+
+> https://godbolt.org/z/fo4dz7Y8e


### PR DESCRIPTION
Can't think of anything clever here.

I also thought it would be nice to use P1061 here for 

```cpp
auto [...Is] = std::make_index_sequence<Str.data.size() - 1>();
```

or even

```cpp
auto [...chars] = Str.data;
return string<chars...>{};
```

But it doesn't appear to be working in the experimental branch: `index_sequence` is not _destructureable_ and `chars` is not `constexpr`.

