### PR TITLE
:sparkles: [277] Solution

### DIFF
--- a/277.md
+++ b/277.md
@@ -73,3 +73,27 @@ int main() {
 > https://godbolt.org/z/qavcThr9K
 
 </p></details><details><summary>Solutions</summary><p>
+
+```cpp
+namespace std {
+
+template <std::size_t N>
+using index_constant = std::integral_constant<std::size_t, N>;
+
+template <auto N, auto... Is>
+auto get(index_sequence<Is...>) {
+    return index_constant<N>{};
+}
+
+template <auto... Is>
+struct tuple_size<index_sequence<Is...>> : index_constant<sizeof...(Is)> {};
+
+template <auto N, auto... Is>
+struct tuple_element<N, index_sequence<Is...>> {
+    using type = index_constant<N>;
+};
+
+}  // namespace std
+```
+
+> https://godbolt.org/z/466j7snqK


### PR DESCRIPTION
I took a bit of liberty with the introduction of `std::index_constant`, but I think it reasonably should exist. Using that greatly simplified the return types by avoiding having to access the `std::index_sequences`, which is relatively onerous.