### PR TITLE
[295] - Did you know that C++23 added stacktrace library?

### DIFF
--- a/tips/295.md
+++ b/tips/295.md
@@ -70,3 +70,23 @@ template <auto N>
  ```
  
 > https://godbolt.org/z/jsdPaP6Px
+
+```cpp
+template <auto N> 
+[[nodiscard]] auto call(auto from) 
+{
+    if constexpr (N > 0)
+    {
+        return call<N-1>(from) + 1;
+    }
+    else
+    {
+        const auto st = std::stacktrace::current();
+        return std::any_of(st.begin(), st.end(), [from](const auto & s) {
+            return from == s.source_line();
+        });
+    }
+}
+```
+ 
+> https://godbolt.org/z/5n7PT4nbn

--- a/tips/295.md
+++ b/tips/295.md
@@ -82,11 +82,11 @@ template <auto N>
     else
     {
         const auto st = std::stacktrace::current();
-        return std::any_of(st.begin(), st.end(), [from](const auto & s) {
+        return std::ranges::any_of(st, [from](const auto & s) {
             return from == s.source_line();
         });
     }
 }
 ```
  
-> https://godbolt.org/z/5n7PT4nbn
+> https://godbolt.org/z/hzj3nd36o


### PR DESCRIPTION
Missed the check for the line number. Added a new example using std::stacktrace and std::stacktrace_entry to retrieve the line number