### PR TITLE
[298] Solution

### DIFF
--- a/tips/298.md
+++ b/tips/298.md
@@ -50,3 +50,10 @@ static_assert(2 == count<e, s, ns, decltype(l), decltype(sl)>);
 > https://godbolt.org/z/McrMfasjq
 
 </p></details><details><summary>Solutions</summary><p>
+
+```c++
+template<class... Ts>
+constexpr auto count = (requires { (void*)&Ts::operator(); } + ... + 0);
+```
+
+> https://godbolt.org/z/Td6zxxaoM


### PR DESCRIPTION
Unlike a simpler `(requires { Ts::operator()(); } + ... + 0);` this also works with `operator()` with arbitrary number of paramters.