### PR TITLE
solution for 320

### DIFF
--- a/tips/320.md
+++ b/tips/320.md
@@ -62,3 +62,39 @@ int main() {
 > https://godbolt.org/z/GnrEh1YM9
 
 </p></details><details><summary>Solutions</summary><p>
+ 
+ ```cpp
+ #include <type_traits>
+#include <array>
+
+namespace impl{
+    template<typename T>
+    struct simd{
+        static constexpr auto dot_product(const T& lhs, const T& rhs) -> void
+        {
+            static_assert(false);
+        }
+    };
+    template<>
+    struct simd<std::vector<float>>{
+        [[nodiscard]] static constexpr auto dot_product(const std::vector<float>& lhs, const std::vector<float>& rhs) -> float
+        {
+            std::array<float, 4> out = {0.0f, 0.0f, 0.0f, 0.0f};\
+            auto vc = _mm_loadu_ps(out.data());
+            for (auto i = 0uz; i < std::size(lhs); i += 4)
+            {
+                const auto va = _mm_loadu_ps(lhs.data() + i);
+                const auto vb = _mm_loadu_ps(rhs.data() + i);
+                vc = _mm_fmadd_ps(va, vb, vc);
+            }
+            _mm_store_ps(out.data(), vc);
+            return out.at(0) + out.at(1) + out.at(2) + out.at(3);
+        }
+    };
+}
+
+[[nodiscard]] constexpr auto dot_product(const auto& lhs, const auto& rhs)
+{
+    return impl::simd<std::remove_cvref_t<decltype(lhs)>>::dot_product(lhs, rhs);
+}
+```


### PR DESCRIPTION
`#include <array>` for 4 float buffer.
`#include <type_traits>` for `std::remove_cvref_t`

Uses template specialization to only allow implemented types (`float` is the only one implemented here). 

Implementation works for 0:N many numbers in each buffer. 

<details><summary>Extra tests for larger input buffers. </summary>

```cpp
"simd.dot_product many more"_test = [] {
      const std::vector a = {1.f, 2.f, 3.f, 4.f, 5.f,  6.f,  7.f};
      const std::vector b = {5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f};

      expect(_i(1*5+2*6+3*7+4*8 + 5*9 + 6*10 + 7*11) == dot_product(a, b));
  };

  "simd.dot_product two buffer"_test = [] {
      const std::vector a = {1.f, 2.f, 3.f, 4.f, 5.f,  6.f,  7.f,  8.f};
      const std::vector b = {5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f};

      expect(_i(1*5+2*6+3*7+4*8 + 5*9 + 6*10 + 7*11 + 8*12) == dot_product(a, b));
  };

  "simd.dot_product three buffer"_test = [] {
      const std::vector a = {1.f, 2.f, 3.f, 4.f, 5.f,  6.f,  7.f,  8.f,  9.f, 10.f, 11.f, 12.f};
      const std::vector b = {5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f, 12.f, 13.f, 14.f, 15.f, 16.f};

      expect(_i(1*5+2*6+3*7+4*8 + 5*9 + 6*10 + 7*11 + 8*12 + 9*13 + 10*14 + 11*15 + 12*16) == dot_product(a, b));
  };
```
</details>