### PR TITLE
add tip 32x changing integral to string_view at compile time

### DIFF
--- a/tips/32x.md
+++ b/tips/32x.md
@@ -1,0 +1,53 @@
+<details open><summary>Info</summary><p>
+
+* **Did you know that integral types can be converted to string_view at compile time**
+
+
+</p></details><details open><summary>Example</summary><p>
+
+```cpp
+#include <concepts>
+#include <limits>
+#include <array>
+#include <string_view>
+#include <cstdio>
+
+template <std::unsigned_integral auto integral>
+struct to_string_view {
+  template <std::size_t size>
+  struct impl_out {
+    std::array<char, size> buffer{};
+    std::size_t idx{};
+  };
+  // Join all strings into a single std::array of chars
+  static constexpr auto impl() noexcept {
+    using integral_t = decltype(integral);
+    constexpr int buffer_size = std::numeric_limits<integral_t>::digits10 + 1;  // Add 1 for null terminator
+    impl_out<buffer_size> result{ .idx = buffer_size - 1 };
+    constexpr int radix = 10; // Base 10 for decimal representation
+    constexpr char digit_chars[] = "0123456789"; // Lookup table for digit characters
+
+    integral_t abs_value = integral;
+
+    do {
+      result.buffer[--result.idx] = digit_chars[abs_value % radix];  // Lookup digit character
+      abs_value /= radix;
+    } while (abs_value != 0);
+
+    return result;
+  }
+  // Give the joined string static storage
+  static constexpr auto res = impl();
+  // View as a std::string_view
+  static constexpr std::string_view value{ res.buffer.data() + res.idx, res.buffer.size() - res.idx - 1 };
+};
+template <std::unsigned_integral auto integral>
+static constexpr auto to_string_view_v = to_string_view<integral>::value;
+
+static_assert(to_string_view_v<10u> == std::string_view{"10"});
+
+int main () {
+    printf("number is: %s length: %zu \n", to_string_view_v<10u>.data(), to_string_view_v<10u>.size());
+}
+
+```


### PR DESCRIPTION
The use case, declare ports for endpoints as compile time string_view instead of being runtime concatenated string