### PR TITLE
Solution to 327

### DIFF
--- a/tips/327.md
+++ b/tips/327.md
@@ -66,4 +66,26 @@ int main() {
 
 </p></details><details><summary>Solutions</summary><p>
 
+ ```cpp
+namespace tip_std {
+    namespace impl {
+        template <class T, size_t... I>
+        constexpr auto make_from_tuple(auto &&tuple, std::index_sequence<I...>) {
+            return T{std::move(std::get<I>(tuple))...};
+        }
+    }  // namespace impl
+    template <class T>
+    constexpr auto make_from_tuple(auto &&tuple) -> T {
+        using tuple_base_t = typename std::remove_cvref_t<decltype(tuple)>;
+        return impl::make_from_tuple<T>(
+            std::forward<decltype(tuple)>(tuple),
+            std::make_index_sequence<std::tuple_size_v<tuple_base_t>>{});
+    }
+    auto forward_as_tuple(auto &&...args) {
+        return std::tuple<decltype(args)...>{std::forward<decltype(args)>(args)...};
+    }
+}  // namespace tip_std
+```
+ https://godbolt.org/z/3qrcjd1Yd
+ 
 </p></details>

--- a/tips/327.md
+++ b/tips/327.md
@@ -86,6 +86,6 @@ namespace tip_std {
     }
 }  // namespace tip_std
 ```
- https://godbolt.org/z/3qrcjd1Yd
+ > https://godbolt.org/z/3qrcjd1Yd
  
 </p></details>


### PR DESCRIPTION
Solution to 327. Details below. 


<details><summary>Details</summary>
<p>
<code>
namespace tip_std {
	namespace impl {
		template <class T, size_t... I>
		constexpr auto make_from_tuple(auto &&tuple, std::index_sequence<I...>) {
			return T{std::move(std::get<I>(tuple))...};
		}
	}  // namespace impl
	template <class T>
	constexpr auto make_from_tuple(auto &&tuple) -> T {
		using tuple_base_t = typename std::remove_cvref_t<decltype(tuple)>;
		return impl::make_from_tuple<T>(
			std::forward<decltype(tuple)>(tuple),
			std::make_index_sequence<std::tuple_size_v<tuple_base_t>>{});
	}
	auto forward_as_tuple(auto &&...args) {
		return std::tuple<decltype(args)...>{std::forward<decltype(args)>(args)...};
	}
}  // namespace tip_std
</code>
</p>
</details> 