### PR TITLE
Fix spelling mistake

### DIFF
--- a/tips/327.md
+++ b/tips/327.md
@@ -28,7 +28,7 @@ int main() {
 ```cpp
 namespace tip_std {
 // TODO: make_from_tuple
-// TODO: forward_as_tupel
+// TODO: forward_as_tuple
 }
 
 struct foo {


### PR DESCRIPTION
instead of spelling `tupel` to `tuple`